### PR TITLE
fix: resolve room service race conditions and harden thread-safety (#83 #84 #85)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,7 +20,7 @@ Board Game Hub is a monorepo consisting of an ASP.NET Core backend and an Angula
 - **Issue Reference:** Link GitHub Issues with `#123` or `fixes #123` where applicable.
 - **Enforcement:** PR titles are strictly linted via GitHub Actions.
 - **Staging:** Do not stage or commit unless explicitly requested.
-- **Feature Tracking:** MANDATORY running trace document in `/docs/traces/` for all **prefixed branches** (e.g., `feat/`, `fix/`, `chore/`) per `.agent/workflows/feature-tracking.md`.
+- **Feature Tracking**: MANDATORY running trace document in `/docs/traces/` for all **prefixed branches**. **Strictly follow the "Finalization Process" (Section 5) in [.agent/workflows/feature-tracking.md](file:///c:/Programming/board%20game%20hub/.agent/workflows/feature-tracking.md) before any commit.**
 
 ### Local Environment
 - **Dependencies:** Use `docker compose up -d postgres pgadmin` for the database.

--- a/backend/BoardGameHub.Api/Hubs/GameHub.cs
+++ b/backend/BoardGameHub.Api/Hubs/GameHub.cs
@@ -220,7 +220,7 @@ public class GameHub : Hub
 
     public async Task RequestUndo(string roomCode)
     {
-        var room = _roomService.RequestUndo(roomCode, Context.ConnectionId);
+        var room = await _roomService.RequestUndo(roomCode, Context.ConnectionId);
         if (room != null)
         {
             // If room returned, check if Vote started or Undo happened
@@ -239,7 +239,7 @@ public class GameHub : Hub
 
     public async Task SubmitUndoVote(string roomCode, bool vote)
     {
-        var room = _roomService.SubmitUndoVote(roomCode, Context.ConnectionId, vote);
+        var room = await _roomService.SubmitUndoVote(roomCode, Context.ConnectionId, vote);
         if (room != null)
         {
             if (room.CurrentVote == null)

--- a/backend/BoardGameHub.Api/Models/Room.cs
+++ b/backend/BoardGameHub.Api/Models/Room.cs
@@ -1,6 +1,7 @@
 namespace BoardGameHub.Api.Models;
 
 using BoardGameHub.Api.Services;
+using System.Collections.Concurrent;
 
 public class Player
 {
@@ -65,7 +66,7 @@ public class Room
 
     // Optimization: Track which top-level properties are dirty
     [System.Text.Json.Serialization.JsonIgnore]
-    public HashSet<string> DirtyMembers { get; set; } = new();
+    public ConcurrentDictionary<string, byte> DirtyMembers { get; } = new();
 }
 
 public class UndoSettings

--- a/backend/BoardGameHub.Api/Services/GameStateManager.cs
+++ b/backend/BoardGameHub.Api/Services/GameStateManager.cs
@@ -85,27 +85,15 @@ public class GameStateManager
         {
             if (_activeRooms.TryGetValue(roomCode, out var room))
             {
-                // We don't lock here to avoid deadlock risks if caller already has lock?
-                // But DirtyMembers is not thread safe? 
-                // Actually HashSet isn't thread safe. 
-                // Caller (RoomService) SHOULD have locked the StateLock.
-                // But MarkDirty might be called from outside lock?
-                // Let's rely on RoomService protecting this.
-                lock(room.DirtyMembers) 
-                {
-                    room.DirtyMembers.Add(member);
-                }
+                room.DirtyMembers.TryAdd(member, 0);
             }
         }
         else
         {
-             // Null member -> Force full diff? 
+             // Null member -> Force full diff
              if (_activeRooms.TryGetValue(roomCode, out var room))
              {
-                 lock(room.DirtyMembers)
-                 {
-                     room.DirtyMembers.Add("ALL");
-                 }
+                 room.DirtyMembers.TryAdd("ALL", 0);
              }
         }
     }
@@ -129,12 +117,14 @@ public class GameStateManager
 
                 _dirtyRooms.TryRemove(roomCode, out _);
 
-                // Check Dirty Members
-                HashSet<string> dirtyMembers;
-                lock (liveRoom.DirtyMembers)
+                // Check Dirty Members - Extract and clear atomically
+                var dirtyMembers = new HashSet<string>();
+                foreach (var key in liveRoom.DirtyMembers.Keys)
                 {
-                    dirtyMembers = new HashSet<string>(liveRoom.DirtyMembers);
-                    liveRoom.DirtyMembers.Clear();
+                    if (liveRoom.DirtyMembers.TryRemove(key, out _))
+                    {
+                        dirtyMembers.Add(key);
+                    }
                 }
 
                 // If no specific members tracked, OR "ALL" is present, do Full Diff

--- a/backend/BoardGameHub.Api/Services/IRoomService.cs
+++ b/backend/BoardGameHub.Api/Services/IRoomService.cs
@@ -32,8 +32,8 @@ public interface IRoomService
     Room? VoteNextGame(string code, string playerId, GameType vote);
     
     // Undo System
-    Room? RequestUndo(string code, string connectionId);
-    Room? SubmitUndoVote(string code, string connectionId, bool vote);
+    Task<Room?> RequestUndo(string code, string connectionId);
+    Task<Room?> SubmitUndoVote(string code, string connectionId, bool vote);
 
     // Stats & Helpers
     List<string> ValidateRooms(List<string> codes);

--- a/backend/BoardGameHub.Api/Services/RoomService.cs
+++ b/backend/BoardGameHub.Api/Services/RoomService.cs
@@ -446,27 +446,27 @@ public class RoomService : IRoomService
     {
         if (!_rooms.TryGetValue(code.ToUpper(), out var room)) return null;
         
-        // Apply settings if provided (Start of Game)
-        if (settings != null)
-        {
-            room.Settings = settings;
-            room.RoundNumber = 0;
-            // Reset Total Scores on new game
-            foreach(var p in room.Players) p.Score = 0;
-        }
-
-        room.RoundNumber++;
-        room.State = GameState.Playing;
-        room.IsPaused = false;
-        room.TimeRemainingWhenPaused = null;
-        
-        // Reset Round Data
-        room.PlayerAnswers.Clear();
-        room.RoundScores.Clear();
-
         await room.StateLock.WaitAsync();
         try
         {
+            // Apply settings if provided (Start of Game)
+            if (settings != null)
+            {
+                room.Settings = settings;
+                room.RoundNumber = 0;
+                // Reset Total Scores on new game
+                foreach(var p in room.Players) p.Score = 0;
+            }
+
+            room.RoundNumber++;
+            room.State = GameState.Playing;
+            room.IsPaused = false;
+            room.TimeRemainingWhenPaused = null;
+            
+            // Reset Round Data
+            room.PlayerAnswers.Clear();
+            room.RoundScores.Clear();
+
             var service = _gameServices.FirstOrDefault(s => s.GameType == room.GameType);
             if (service != null)
             {
@@ -565,11 +565,6 @@ public class RoomService : IRoomService
     {
         if (!_rooms.TryGetValue(code.ToUpper(), out var room)) return null;
 
-        if (actionType != "SUBMIT_STROKE") 
-        {
-            SaveState(room);
-        }
-
         var service = _gameServices.FirstOrDefault(s => s.GameType == room.GameType);
         if (service != null)
         {
@@ -579,6 +574,11 @@ public class RoomService : IRoomService
             await room.StateLock.WaitAsync();
             try
             {
+                if (actionType != "SUBMIT_STROKE") 
+                {
+                    SaveStateLocked(room);
+                }
+
                 success = await service.HandleAction(room, action, connectionId);
             }
             finally
@@ -773,8 +773,9 @@ public class RoomService : IRoomService
     }
 
     // --- UNDO SYSTEM ---
+    // Note: All Save/Undo methods MUST be called within a room.StateLock context.
 
-    private void SaveState(Room room)
+    private void SaveStateLocked(Room room)
     {
         // Snapshot the State, RoundNumber, and GameData
         // We serialize the specific properties relevant to gameplay restore
@@ -811,82 +812,98 @@ public class RoomService : IRoomService
         }
     }
 
-    public Room? RequestUndo(string code, string connectionId)
+    public async Task<Room?> RequestUndo(string code, string connectionId)
     {
         if (!_rooms.TryGetValue(code.ToUpper(), out var room)) return null;
         
-        // If no history, can't undo
-        if (room.StateHistory.Count == 0) return null;
-
-        var player = room.Players.FirstOrDefault(p => p.ConnectionId == connectionId);
-        if (player == null) return null;
-
-        // 1. Host Only Mode (or Host is requesting)
-        if (room.UndoSettings.HostOnly || player.IsHost)
+        await room.StateLock.WaitAsync();
+        try
         {
-             // Host can bypass vote? Or if HostOnly is TRUE.
-             // If HostOnly=True and Player isn't Host -> Deny.
-             if (room.UndoSettings.HostOnly && !player.IsHost) return null;
+            // If no history, can't undo
+            if (room.StateHistory.Count == 0) return null;
 
-             return PerformUndo(code); 
-        }
+            var player = room.Players.FirstOrDefault(p => p.ConnectionId == connectionId);
+            if (player == null) return null;
 
-        // 2. Default Voting Mode (and player is not host, or Voting is ON)
-        if (room.UndoSettings.AllowVoting)
-        {
-            // Start a Vote
-            room.CurrentVote = new UndoVote
+            // 1. Host Only Mode (or Host is requesting)
+            if (room.UndoSettings.HostOnly || player.IsHost)
             {
-                InitiatorId = connectionId,
-                InitiatorName = player.Name,
-                CreatedAt = DateTime.UtcNow
-            };
-            // Implicit "Yes" from initiator
-            room.CurrentVote.Votes[connectionId] = true;
-            
-            _gameStateManager.MarkDirty(room.Code);
-            NotifyStatsChanged();
-            return room; // Caller will broadcast "UndoVoteStarted"
+                 // Host can bypass vote? Or if HostOnly is TRUE.
+                 // If HostOnly=True and Player isn't Host -> Deny.
+                 if (room.UndoSettings.HostOnly && !player.IsHost) return null;
+
+                 return PerformUndoLocked(room); 
+            }
+
+            // 2. Default Voting Mode (and player is not host, or Voting is ON)
+            if (room.UndoSettings.AllowVoting)
+            {
+                // Start a Vote
+                room.CurrentVote = new UndoVote
+                {
+                    InitiatorId = connectionId,
+                    InitiatorName = player.Name,
+                    CreatedAt = DateTime.UtcNow
+                };
+                // Implicit "Yes" from initiator
+                room.CurrentVote.Votes[connectionId] = true;
+                
+                _gameStateManager.MarkDirty(room.Code);
+                NotifyStatsChanged();
+                return room; // Caller will broadcast "UndoVoteStarted"
+            }
+        }
+        finally
+        {
+            room.StateLock.Release();
         }
 
         return null;
     }
 
-    public Room? SubmitUndoVote(string code, string connectionId, bool vote)
+    public async Task<Room?> SubmitUndoVote(string code, string connectionId, bool vote)
     {
         if (!_rooms.TryGetValue(code.ToUpper(), out var room)) return null;
-        if (room.CurrentVote == null) return null;
-
-        room.CurrentVote.Votes[connectionId] = vote;
         
-        // Check for Majority
-        var totalPlayers = room.Players.Count;
-        var castVotes = room.CurrentVote.Votes.Count;
-        var yesVotes = room.CurrentVote.Votes.Values.Count(v => v);
-
-        // If simple majority reached ( > 50% of TOTAL players)
-        if (yesVotes > totalPlayers / 2.0)
+        await room.StateLock.WaitAsync();
+        try
         {
-            room.CurrentVote = null; // Vote passed
-            return PerformUndo(code);
-        }
-        
-        // If impossible to win (No votes >= 50%)
-        // or everyone voted
-        if (castVotes == totalPlayers)
-        {
-            // Vote Finished, failed
-            room.CurrentVote = null;
-        }
+            if (room.CurrentVote == null) return null;
 
-        _gameStateManager.MarkDirty(room.Code);
-        NotifyStatsChanged();
-        return room;
+            room.CurrentVote.Votes[connectionId] = vote;
+            
+            // Check for Majority
+            var totalPlayers = room.Players.Count;
+            var castVotes = room.CurrentVote.Votes.Count;
+            var yesVotes = room.CurrentVote.Votes.Values.Count(v => v);
+
+            // If simple majority reached ( > 50% of TOTAL players)
+            if (yesVotes > totalPlayers / 2.0)
+            {
+                room.CurrentVote = null; // Vote passed
+                return PerformUndoLocked(room);
+            }
+            
+            // If impossible to win (No votes >= 50%)
+            // or everyone voted
+            if (castVotes == totalPlayers)
+            {
+                // Vote Finished, failed
+                room.CurrentVote = null;
+            }
+
+            _gameStateManager.MarkDirty(room.Code);
+            NotifyStatsChanged();
+            return room;
+        }
+        finally
+        {
+            room.StateLock.Release();
+        }
     }
 
-    private Room? PerformUndo(string code)
+    private Room? PerformUndoLocked(Room currentRoom)
     {
-        if (!_rooms.TryGetValue(code.ToUpper(), out var currentRoom)) return null;
         if (currentRoom.StateHistory.Count == 0) return null;
 
         var snapshot = currentRoom.StateHistory.Pop();
@@ -896,21 +913,7 @@ public class RoomService : IRoomService
             var oldState = JsonSerializer.Deserialize<Room>(snapshot, options);
             
             if (oldState == null) return null;
-
-            // RESTORE CRITICAL STATE
-            // We want to keep the *current* network connections if possible, 
-            // OR we assume the snapshot Players are the same people. 
-            // The safest bet for "Game State" undo is to restore GameData, State, RoundNumber, Scores.
-            // But KEEP the current Players list (so nobody gets kicked out connectivity-wise).
-            // BUT, if the undo involves "Undo Player Joining", then we SHOULD restore Players list.
-            // Given the complexity, let's restore EVERYTHING but try to merge ConnectionIds?
-            // Actually, for a MVP local/friends game, restoring the whole object is fine. 
-            // If a player joined AFTER the snapshot, and we undo, they effectively "un-join" in logic,
-            // but their socket is still connected. They might get an error next time they try to act.
-            // That's acceptable for "Undo". 
             
-            var existingPlayers = currentRoom.Players; // Keep ref to current sockets
-
             // Overwrite properties
             currentRoom.GameType = oldState.GameType;
             currentRoom.State = oldState.State;
@@ -920,8 +923,6 @@ public class RoomService : IRoomService
             currentRoom.PlayerAnswers = oldState.PlayerAnswers;
             
             // Re-assign generic GameData requires careful deserialization if it became JsonElement
-            // The JsonSerializer might have turned `object` GameData into `JsonElement`.
-            // We need to re-deserialize it to the specific type (JustOneState, ScatterbrainState, etc.).
             if (currentRoom.GameData is JsonElement jsonElement)
             {
                  var service = _gameServices.FirstOrDefault(s => s.GameType == currentRoom.GameType);
@@ -937,7 +938,7 @@ public class RoomService : IRoomService
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Undo Failed: {ex.Message}");
+            _logger.LogError(ex, "Undo Failed for room {RoomCode}", currentRoom.Code);
             return null;
         }
     }

--- a/backend/BoardGameHub.Tests/Hubs/GameHubTests.cs
+++ b/backend/BoardGameHub.Tests/Hubs/GameHubTests.cs
@@ -271,7 +271,7 @@ public class GameHubTests
         // Arrange
         var vote = new UndoVote { InitiatorName = "P1" };
         var room = new Room { Code = "TEST", CurrentVote = vote };
-        _mockRoomService.Setup(r => r.RequestUndo("TEST", "conn1")).Returns(room);
+        _mockRoomService.Setup(r => r.RequestUndo("TEST", "conn1")).ReturnsAsync(room);
 
         // Act
         await _sut.RequestUndo("TEST");
@@ -286,7 +286,7 @@ public class GameHubTests
         // Arrange
         var vote = new UndoVote { InitiatorName = "P1" };
         var room = new Room { Code = "TEST", CurrentVote = vote };
-        _mockRoomService.Setup(r => r.SubmitUndoVote("TEST", "conn1", true)).Returns(room);
+        _mockRoomService.Setup(r => r.SubmitUndoVote("TEST", "conn1", true)).ReturnsAsync(room);
 
         // Act
         await _sut.SubmitUndoVote("TEST", true);
@@ -300,7 +300,7 @@ public class GameHubTests
     {
         // Arrange
         var room = new Room { Code = "TEST", CurrentVote = null };
-        _mockRoomService.Setup(r => r.SubmitUndoVote("TEST", "conn1", true)).Returns(room);
+        _mockRoomService.Setup(r => r.SubmitUndoVote("TEST", "conn1", true)).ReturnsAsync(room);
 
         // Act
         await _sut.SubmitUndoVote("TEST", true);

--- a/backend/BoardGameHub.Tests/Services/Core/RoomServiceTests.cs
+++ b/backend/BoardGameHub.Tests/Services/Core/RoomServiceTests.cs
@@ -106,7 +106,7 @@ public class RoomServiceTests
     }
 
     [Fact]
-    public void StartGame_ShouldSetState_AndInvokeGameService()
+    public async Task StartGame_ShouldSetState_AndInvokeGameService()
     {
         // Arrange
         var room = _sut.CreateRoom("host1", "Host", true, GameType.Scatterbrain);
@@ -116,7 +116,7 @@ public class RoomServiceTests
         _gameServices.Add(mockService.Object);
 
         // Act
-        _sut.StartGame(room.Code, new GameSettings { TimerDurationSeconds = 60 });
+        await _sut.StartGame(room.Code, new GameSettings { TimerDurationSeconds = 60 });
 
         // Assert
         room.State.Should().Be(GameState.Playing);
@@ -257,7 +257,7 @@ public class RoomServiceTests
     }
 
     [Fact]
-    public void RequestUndo_ShouldStartVote_WhenNonHostRequests()
+    public async Task RequestUndo_ShouldStartVote_WhenNonHostRequests()
     {
         // Arrange
         var room = _sut.CreateRoom("host1", "Host", true);
@@ -266,7 +266,7 @@ public class RoomServiceTests
         _sut.UpdateUndoSettings(room.Code, new UndoSettings { AllowVoting = true, HostOnly = false });
 
         // Act
-        var result = _sut.RequestUndo(room.Code, "conn2");
+        var result = await _sut.RequestUndo(room.Code, "conn2");
 
         // Assert
         result.Should().NotBeNull();
@@ -275,7 +275,7 @@ public class RoomServiceTests
     }
 
     [Fact]
-    public void SubmitUndoVote_ShouldRevertStateOnSuccess()
+    public async Task SubmitUndoVote_ShouldRevertStateOnSuccess()
     {
         // Arrange
         var room = _sut.CreateRoom("host1", "Host", true);
@@ -283,10 +283,10 @@ public class RoomServiceTests
         _sut.JoinRoom(room.Code, "conn3", "Player3"); // 3 players total, need 2 votes for majority (> 50% of 3 is 1.5 -> 2)
         room.StateHistory.Push("{}");
         _sut.UpdateUndoSettings(room.Code, new UndoSettings { AllowVoting = true, HostOnly = false });
-        _sut.RequestUndo(room.Code, "conn2"); // Initiator conn2 votes Yes automatically
+        await _sut.RequestUndo(room.Code, "conn2"); // Initiator conn2 votes Yes automatically
 
         // Act
-        var result = _sut.SubmitUndoVote(room.Code, "conn3", true); // Second Yes vote -> Majority reached
+        var result = await _sut.SubmitUndoVote(room.Code, "conn3", true); // Second Yes vote -> Majority reached
 
         // Assert
         result.Should().NotBeNull();
@@ -319,42 +319,42 @@ public class RoomServiceTests
     }
 
     [Fact]
-    public void RequestUndo_HostOnly_ShouldPerformUndoImmediately()
+    public async Task RequestUndo_HostOnly_ShouldPerformUndoImmediately()
     {
         var room = _sut.CreateRoom("host1", "Host", true);
         room.StateHistory.Push("{}");
         _sut.UpdateUndoSettings(room.Code, new UndoSettings { HostOnly = true });
 
-        var result = _sut.RequestUndo(room.Code, "host1");
+        var result = await _sut.RequestUndo(room.Code, "host1");
 
         result.Should().NotBeNull();
         room.StateHistory.Count.Should().Be(0);
     }
 
     [Fact]
-    public void RequestUndo_HostOnly_NonHost_ShouldReturnNull()
+    public async Task RequestUndo_HostOnly_NonHost_ShouldReturnNull()
     {
         var room = _sut.CreateRoom("host1", "Host", true);
         _sut.JoinRoom(room.Code, "conn2", "Player2");
         room.StateHistory.Push("{}");
         _sut.UpdateUndoSettings(room.Code, new UndoSettings { HostOnly = true });
 
-        var result = _sut.RequestUndo(room.Code, "conn2");
+        var result = await _sut.RequestUndo(room.Code, "conn2");
 
         result.Should().BeNull();
         room.StateHistory.Count.Should().Be(1);
     }
 
     [Fact]
-    public void SubmitUndoVote_ShouldCloseVoteOnTotalCastWithoutMajority()
+    public async Task SubmitUndoVote_ShouldCloseVoteOnTotalCastWithoutMajority()
     {
         var room = _sut.CreateRoom("host1", "Host", true);
         _sut.JoinRoom(room.Code, "conn2", "Player2"); // 2 players total. Majority needed: > 2/2 = 1 (so 2).
         room.StateHistory.Push("{}");
         _sut.UpdateUndoSettings(room.Code, new UndoSettings { AllowVoting = true, HostOnly = false });
-        _sut.RequestUndo(room.Code, "conn2"); // conn2 says Yes
+        await _sut.RequestUndo(room.Code, "conn2"); // conn2 says Yes
         
-        var result = _sut.SubmitUndoVote(room.Code, "host1", false); // host1 says No. 1 Yes, 1 No. 
+        var result = await _sut.SubmitUndoVote(room.Code, "host1", false); // host1 says No. 1 Yes, 1 No. 
 
         result.Should().NotBeNull();
         result!.CurrentVote.Should().BeNull(); // Closed because everyone voted
@@ -382,5 +382,56 @@ public class RoomServiceTests
         await _sut.SubmitAction(room.Code, "conn1", "SUBMIT_STROKE", null);
 
         room.StateHistory.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StartGame_Concurrency_ShouldSerializeMutations()
+    {
+        // Arrange
+        var room = _sut.CreateRoom("CONC_START", "Host", true, GameType.Scatterbrain);
+        var mockService = new Mock<IGameService>();
+        mockService.Setup(s => s.GameType).Returns(GameType.Scatterbrain);
+        // Simulate a delay in StartRound to increase race window
+        mockService.Setup(s => s.StartRound(It.IsAny<Room>(), It.IsAny<GameSettings>()))
+            .Returns(async () => await Task.Delay(50));
+        _gameServices.Add(mockService.Object);
+
+        // Act - Call StartGame twice simultaneously
+        // First call passes settings (resets game), second call passes null (increments round)
+        var t1 = _sut.StartGame(room.Code, new GameSettings());
+        var t2 = _sut.StartGame(room.Code, null);
+
+        await Task.WhenAll(t1, t2);
+
+        // Assert
+        room.RoundNumber.Should().Be(2); // Exactly 2 rounds incremented
+        mockService.Verify(s => s.StartRound(It.IsAny<Room>(), It.IsAny<GameSettings>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task RequestUndo_ConcurrentVotes_ShouldHandleMajorityCorrectly()
+    {
+        // Arrange
+        var room = _sut.CreateRoom("CONC_UNDO", "Host", true);
+        _sut.JoinRoom(room.Code, "p2", "Player2");
+        _sut.JoinRoom(room.Code, "p3", "Player3");
+        _sut.JoinRoom(room.Code, "p4", "Player4");
+        _sut.JoinRoom(room.Code, "p5", "Player5"); // 5 players total, majority (> 2.5) is 3 votes
+        
+        room.StateHistory.Push("{}");
+        _sut.UpdateUndoSettings(room.Code, new UndoSettings { AllowVoting = true, HostOnly = false });
+
+        // Act - Start undo and cast multiple votes rapidly
+        await _sut.RequestUndo(room.Code, "p2"); // Vote 1 (Yes)
+        
+        var t1 = _sut.SubmitUndoVote(room.Code, "p3", true); // Vote 2 (Yes)
+        var t2 = _sut.SubmitUndoVote(room.Code, "p4", true); // Vote 3 (Yes) -> Majority!
+        var t3 = _sut.SubmitUndoVote(room.Code, "p5", true); // Vote 4 (Yes) -> Should be ignored as finished
+
+        await Task.WhenAll(t1, t2, t3);
+
+        // Assert
+        room.StateHistory.Count.Should().Be(0); // Successfully reverted
+        room.CurrentVote.Should().BeNull(); // Closed
     }
 }

--- a/backend/BoardGameHub.Tests/Services/GameStateManagerTests.cs
+++ b/backend/BoardGameHub.Tests/Services/GameStateManagerTests.cs
@@ -149,4 +149,67 @@ public class GameStateManagerTests
                  It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task MarkDirty_ConcurrentCalls_ShouldNotThrow()
+    {
+        // Arrange
+        var room = new Room { Code = "CONC1" };
+        _manager.TrackRoom(room);
+        var tasks = new List<Task>();
+        int callCount = 100;
+
+        // Act & Assert
+        for (int i = 0; i < callCount; i++)
+        {
+            int index = i;
+            tasks.Add(Task.Run(() => _manager.MarkDirty("CONC1", $"Member{index}")));
+        }
+
+        await Task.WhenAll(tasks);
+        
+        // Verify DirtyMembers has correct count (using reflection since internal)
+        var dirtyMembers = room.DirtyMembers;
+        dirtyMembers.Count.Should().Be(callCount + 1); // +1 for the "ALL" member added in TrackRoom
+    }
+
+    [Fact]
+    public async Task GameTick_ExtractionWhileAdding_ShouldBeConsistent()
+    {
+        // Arrange
+        var room = new Room { Code = "EXTRACT1" };
+        _manager.TrackRoom(room);
+        bool running = true;
+
+        // Start a background task that keeps adding dirty members
+        var adderTask = Task.Run(async () => {
+            int i = 0;
+            while (running)
+            {
+                _manager.MarkDirty("EXTRACT1", $"Member{i++}");
+                if (i % 10 == 0) await Task.Delay(1); // Yield lightly
+            }
+        });
+
+        // Act - Run multiple ticks
+        try
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                await InvokeGameTickAsync();
+                await Task.Delay(10);
+            }
+        }
+        finally
+        {
+            running = false;
+            await adderTask;
+        }
+
+        // Assert - If we reached here without exception, it's a pass.
+        // Collection modification exceptions were the primary target of #85.
+        _mockClientProxy.Verify(
+            c => c.SendCoreAsync("RoomStatePatch", It.IsAny<object[]>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce());
+    }
 }

--- a/docs/traces/fix-83-room-service-locking-work-trace.md
+++ b/docs/traces/fix-83-room-service-locking-work-trace.md
@@ -1,0 +1,46 @@
+# fix/83-room-service-locking Work Trace
+
+## 1) Planned Work
+- **TODO List**:
+    - [x] Move state mutations in `RoomService.StartGame` (#83) inside the `StateLock` block.
+    - [x] Move `SaveState` call in `RoomService.SubmitAction` (#84) inside the `StateLock` block.
+    - [x] Rename `SaveState` to `SaveStateLocked` and ensure it's thread-safe (expects lock).
+    - [x] Audit `RoomService` for other "mutation-before-lock" patterns.
+    - [x] Replace `Room.DirtyMembers` (#85) with `ConcurrentDictionary<string, byte>`.
+    - [x] Update `GameStateManager.MarkDirty` and `GameTick` for #85.
+    - [x] Verify `RequestUndo`, `SubmitUndoVote`, and `PerformUndo` use the lock.
+    - [x] Update `IRoomService.cs` and `GameHub.cs` for async Undo support.
+    - [x] Implement additional concurrency stress tests for `GameStateManager`.
+    - [x] Implement additional serialization tests for `RoomService` (`StartGame`, `Undo`).
+    - [x] Update `GEMINI.md` workflow baseline.
+    - [x] Final Audit & Verification.
+- **File List**:
+    - `GEMINI.md`: Updated workflow baseline.
+    - `backend/BoardGameHub.Api/Services/RoomService.cs`: Fixed locking in `StartGame`, `SubmitAction`, and Undo methods.
+    - `backend/BoardGameHub.Api/Models/Room.cs`: Updated `DirtyMembers` to `ConcurrentDictionary`.
+    - `backend/BoardGameHub.Api/Services/GameStateManager.cs`: Updated for thread-safe field tracking.
+    - `backend/BoardGameHub.Api/Services/IRoomService.cs`: Migrated Undo methods to Task-returning.
+    - `backend/BoardGameHub.Api/Hubs/GameHub.cs`: Added `await` for async room service calls.
+    - `backend/BoardGameHub.Tests/Hubs/GameHubTests.cs`: Fixed mock signatures.
+    - `backend/BoardGameHub.Tests/Services/Core/RoomServiceTests.cs`: Added concurrency/serialization tests.
+    - `backend/BoardGameHub.Tests/Services/GameStateManagerTests.cs`: Added stress tests for `DirtyMembers`.
+- **Rationale**: 
+    - `RoomService.cs`: Resolves P0 race conditions where state is modified while other threads (like the 50ms pulse) might be reading it (Fix #83, #84).
+    - `Room.cs` & `GameStateManager.cs`: Fixes thread-safety issues with field tracking to prevent crashes during concurrent updates (Fix #85).
+
+## 2) In Progress Work
+- None.
+
+## 3) Completed Work
+- **Locking Consolidation**: Moved all critical game state mutations in `RoomService` inside `StateLock` blocks.
+- **Thread-Safe Field Tracking**: Replaced `HashSet` with `ConcurrentDictionary` for `Room.DirtyMembers`, eliminating race conditions in the high-frequency sync loop.
+- **Async Undo Migration**: Refactored `RequestUndo` and `SubmitUndoVote` to be async, allowing for non-blocking `StateLock` acquisition and fixing gaps where mutations happened outside locks.
+- **Robust Testing**: Added 4 new concurrency/stress tests to verify that these fixes hold up under high-load simultaneous access.
+- **Workflow Baseline**: Hardened `GEMINI.md` to prevent future unauthorized commits by mandating-final audit reviews.
+- **Verification**: Verified via `dotnet build` and success of 216/216 backend tests.
+
+## 4) Issues and Out of Scope
+- **4a) Potential Blockers**:
+    - None.
+- **4b) Opportunities**:
+    - The `StateLock` pattern is robust but requires discipline. Consider a wrapper or decorator for `IGameService` methods to ensure locking is always handled at the `RoomService` entry point.


### PR DESCRIPTION
This PR resolves critical race conditions and thread-safety issues in the backend orchestration layer.

### Key Changes
- **Locking Consolidation (#83, #84)**: Moved StartGame and SubmitAction mutations inside the StateLock blocks.
- **Thread-Safe Field Tracking (#85)**: Replaced HashSet with ConcurrentDictionary for DirtyMembers and implemented atomic TryRemove extraction in the sync loop.
- **Undo Refactor**: Migrated RequestUndo and SubmitUndoVote to be async and properly serialized.
- **Verification**: Added 4 new concurrency stress tests. Total 216/216 backend tests passed.
- **Workflow**: Updated GEMINI.md to mandate final audit reviews before commits.

Detailed work trace: docs/traces/fix-83-room-service-locking-work-trace.md